### PR TITLE
[configuration] add suggestSync function

### DIFF
--- a/src/configurationvalue.cpp
+++ b/src/configurationvalue.cpp
@@ -34,7 +34,6 @@
 #include <QDebug>
 #include <QDateTime>
 #include <QUrl>
-#include <QProcess>
 
 #include "configurationvalue.h"
 
@@ -102,9 +101,8 @@ void ConfigurationValue::setDefaultValue(const QVariant &value)
         emit valueChanged();
 }
 
-void ConfigurationValue::forceSync()
+void ConfigurationValue::suggestSync()
 {
-    QProcess forceSync;
-    forceSync.start("/usr/bin/killall gconfd-2");
-    forceSync.waitForFinished();
+    if (mItem)
+        mItem->sync();
 }

--- a/src/configurationvalue.cpp
+++ b/src/configurationvalue.cpp
@@ -34,6 +34,7 @@
 #include <QDebug>
 #include <QDateTime>
 #include <QUrl>
+#include <QProcess>
 
 #include "configurationvalue.h"
 
@@ -99,4 +100,11 @@ void ConfigurationValue::setDefaultValue(const QVariant &value)
     // if changing the default changed the value, emit valueChanged
     if (value != oldValue)
         emit valueChanged();
+}
+
+void ConfigurationValue::forceSync()
+{
+    QProcess forceSync;
+    forceSync.start("/usr/bin/killall gconfd-2");
+    forceSync.waitForFinished();
 }

--- a/src/configurationvalue.h
+++ b/src/configurationvalue.h
@@ -57,6 +57,8 @@ public:
     QVariant defaultValue() const;
     void setDefaultValue(const QVariant &defaultValue);
 
+    Q_INVOKABLE void forceSync();
+
 signals:
     void keyChanged();
     void valueChanged();

--- a/src/configurationvalue.h
+++ b/src/configurationvalue.h
@@ -57,7 +57,7 @@ public:
     QVariant defaultValue() const;
     void setDefaultValue(const QVariant &defaultValue);
 
-    Q_INVOKABLE void forceSync();
+    Q_INVOKABLE void suggestSync();
 
 signals:
     void keyChanged();


### PR DESCRIPTION
Some gconf settings would be nice to be forceSynced. 
Ie devicelock settings vs user removes battery right setting the config value.